### PR TITLE
Fix Infinity comparison unit bug

### DIFF
--- a/scripts/civclicker-update.js
+++ b/scripts/civclicker-update.js
@@ -168,7 +168,7 @@ function updatePurchaseRow(purchaseObj) {
 		// Treat 'custom' or Infinity as +/-1.
 		// xxx Should we treat 'custom' as its appropriate value instead?
 		let absQty = abs(purchaseQty);
-		if ((absQty === "custom") || (absQty === Infinity)) {
+		if ((absQty === "custom") || (absQty === "Infinity")) {
 			purchaseQty = sgn(purchaseQty);
 		}
 		elt.disabled = ((purchaseQty > maxQty) || (purchaseQty < minQty));


### PR DESCRIPTION
### Issue:
`+ ∞` and `- ∞` buttons were always disabled.

### Cause:
The data was being derived directly from the button element, and thus was a string. A strict comparison of `Infinity === 'Infinity'` will always return false.