### PR TITLE
Fix Deity Section not loading

### DIFF
--- a/scripts/civclicker-update.js
+++ b/scripts/civclicker-update.js
@@ -439,7 +439,7 @@ function updateUpgrades(upgradeData) {
 	const civData = civInterface.getCivData();
 	const worshipOwned = civInterface.getWorshipOwned();
 	let domain = civInterface.getCurDeityDomain();
-	let hasDomain = Boolean(domain === "");
+	let hasDomain = Boolean(domain !== "");
 	let canSelectDomain = Boolean(worshipOwned && !hasDomain);
 
 	// Update all of the upgrades

--- a/scripts/civclicker.js
+++ b/scripts/civclicker.js
@@ -3350,6 +3350,8 @@ const pageActions = {
 	startWonder,
 	wonderSelect,
 	// Actions tied to upgrades (?)
+	selectDeity,
+	onPurchase,
 	raiseDead,
 	summonShade,
 	wickerman,


### PR DESCRIPTION
### Issue:

Deity section would not ever show a pantheon to select.

### Cause:

- Incorrect Boolean check
- Functions not being exported in the global scope