### PR TITLE
Fix upgrades not going away

### DIFF
--- a/scripts/civclicker-update.js
+++ b/scripts/civclicker-update.js
@@ -150,11 +150,14 @@ function updatePurchaseRow(purchaseObj) {
 	let havePrereqs = (purchaseObj.owned > 0)
 		|| civInterface.meetsUpgradePrereqs(purchaseObj.prereqs);
 
+	let isOwned = typeof purchaseObj.owned === 'boolean'
+		? purchaseObj.owned
+		: purchaseObj.owned === purchaseObj.limit;
 	// Special check: Hide one-shot upgrades after purchase; they're
 	// redisplayed elsewhere.
 	let hideBoughtUpgrade = (
 		(purchaseObj.type === "upgrade")
-		&& (purchaseObj.owned === purchaseObj.limit)
+		&& (isOwned)
 		&& !purchaseObj.salable
 	);
 


### PR DESCRIPTION
### Issue:

Upgrades would still be clickable after purchase (and would subtract from resources for payment)

### Cause:

Ownership was only ever evaluated as a number against `limit`, not a boolean (if a boolean)